### PR TITLE
Add type picker and inline type badges

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@codemirror/commands": "^6.10.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.39.8",
+    "@kobalte/core": "^0.13.11",
     "@livestore/adapter-web": "^0.3.1",
     "@livestore/livestore": "^0.3.1",
     "@livestore/solid": "^0.3.1",

--- a/apps/web/src/__tests__/Block/Movement.browser.spec.tsx
+++ b/apps/web/src/__tests__/Block/Movement.browser.spec.tsx
@@ -210,4 +210,256 @@ describe("Block Movement", () => {
       }).pipe(runtime.runPromise);
     });
   });
+
+  describe("Block Selection Mode", () => {
+    describe("Swap Up (Opt+Cmd+Up)", () => {
+      it("swaps single selected block with previous sibling", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+            ]);
+
+          const [first, second, third] = childNodeIds;
+          const secondBlockId = Id.makeBlockId(bufferId, second);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(secondBlockId);
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowUp}{/Meta}{/Alt}");
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [second, first, third]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [second]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("swaps multiple selected blocks with previous sibling", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+              { text: "Fourth" },
+            ]);
+
+          const [first, second, third, fourth] = childNodeIds;
+          const secondBlockId = Id.makeBlockId(bufferId, second);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          // Enter block selection on second, extend to third
+          yield* When.USER_ENTERS_BLOCK_SELECTION(secondBlockId);
+          yield* When.USER_PRESSES("{Shift>}{ArrowDown}{/Shift}");
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowUp}{/Meta}{/Alt}");
+
+          // [A, B, C, D] → [B, C, A, D]
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [second, third, first, fourth]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [second, third]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("does nothing when first block is selected", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+            ]);
+
+          const [first, second] = childNodeIds;
+          const firstBlockId = Id.makeBlockId(bufferId, first);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(firstBlockId);
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowUp}{/Meta}{/Alt}");
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [first, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [first]);
+        }).pipe(runtime.runPromise);
+      });
+    });
+
+    describe("Swap Down (Opt+Cmd+Down)", () => {
+      it("swaps single selected block with next sibling", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+            ]);
+
+          const [first, second, third] = childNodeIds;
+          const secondBlockId = Id.makeBlockId(bufferId, second);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(secondBlockId);
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowDown}{/Meta}{/Alt}");
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [first, third, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [second]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("swaps multiple selected blocks with next sibling", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+              { text: "Fourth" },
+            ]);
+
+          const [first, second, third, fourth] = childNodeIds;
+          const secondBlockId = Id.makeBlockId(bufferId, second);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          // Enter block selection on second, extend to third
+          yield* When.USER_ENTERS_BLOCK_SELECTION(secondBlockId);
+          yield* When.USER_PRESSES("{Shift>}{ArrowDown}{/Shift}");
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowDown}{/Meta}{/Alt}");
+
+          // [A, B, C, D] → [A, D, B, C]
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [first, fourth, second, third]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [second, third]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("does nothing when last block is selected", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+            ]);
+
+          const [first, second] = childNodeIds;
+          const secondBlockId = Id.makeBlockId(bufferId, second);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(secondBlockId);
+          yield* When.USER_PRESSES("{Alt>}{Meta>}{ArrowDown}{/Meta}{/Alt}");
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [first, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [second]);
+        }).pipe(runtime.runPromise);
+      });
+    });
+
+    describe("Move to First (Shift+Opt+Cmd+Up)", () => {
+      it("moves single selected block to first position", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+            ]);
+
+          const [first, second, third] = childNodeIds;
+          const thirdBlockId = Id.makeBlockId(bufferId, third);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(thirdBlockId);
+          yield* When.USER_PRESSES(
+            "{Shift>}{Alt>}{Meta>}{ArrowUp}{/Meta}{/Alt}{/Shift}",
+          );
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [third, first, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [third]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("moves multiple selected blocks to first position", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+              { text: "Fourth" },
+            ]);
+
+          const [first, second, third, fourth] = childNodeIds;
+          const thirdBlockId = Id.makeBlockId(bufferId, third);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          // Enter block selection on third, extend to fourth
+          yield* When.USER_ENTERS_BLOCK_SELECTION(thirdBlockId);
+          yield* When.USER_PRESSES("{Shift>}{ArrowDown}{/Shift}");
+          yield* When.USER_PRESSES(
+            "{Shift>}{Alt>}{Meta>}{ArrowUp}{/Meta}{/Alt}{/Shift}",
+          );
+
+          // [A, B, C, D] → [C, D, A, B]
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [third, fourth, first, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [third, fourth]);
+        }).pipe(runtime.runPromise);
+      });
+    });
+
+    describe("Move to Last (Shift+Opt+Cmd+Down)", () => {
+      it("moves single selected block to last position", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+            ]);
+
+          const [first, second, third] = childNodeIds;
+          const firstBlockId = Id.makeBlockId(bufferId, first);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          yield* When.USER_ENTERS_BLOCK_SELECTION(firstBlockId);
+          yield* When.USER_PRESSES(
+            "{Shift>}{Alt>}{Meta>}{ArrowDown}{/Meta}{/Alt}{/Shift}",
+          );
+
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [second, third, first]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [first]);
+        }).pipe(runtime.runPromise);
+      });
+
+      it("moves multiple selected blocks to last position", async () => {
+        await Effect.gen(function* () {
+          const { bufferId, rootNodeId, childNodeIds } =
+            yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+              { text: "First" },
+              { text: "Second" },
+              { text: "Third" },
+              { text: "Fourth" },
+            ]);
+
+          const [first, second, third, fourth] = childNodeIds;
+          const firstBlockId = Id.makeBlockId(bufferId, first);
+
+          render(() => <EditorBuffer bufferId={bufferId} />);
+
+          // Enter block selection on first, extend to second
+          yield* When.USER_ENTERS_BLOCK_SELECTION(firstBlockId);
+          yield* When.USER_PRESSES("{Shift>}{ArrowDown}{/Shift}");
+          yield* When.USER_PRESSES(
+            "{Shift>}{Alt>}{Meta>}{ArrowDown}{/Meta}{/Alt}{/Shift}",
+          );
+
+          // [A, B, C, D] → [C, D, A, B]
+          yield* Then.CHILDREN_ORDER_IS(rootNodeId, [third, fourth, first, second]);
+          yield* Then.BLOCKS_ARE_SELECTED(bufferId, [first, second]);
+        }).pipe(runtime.runPromise);
+      });
+    });
+  });
 });

--- a/apps/web/src/__tests__/TitleTypePicker.browser.spec.tsx
+++ b/apps/web/src/__tests__/TitleTypePicker.browser.spec.tsx
@@ -1,0 +1,243 @@
+import "@/index.css";
+import { System } from "@/schema";
+import { NodeT } from "@/services/domain/Node";
+import { TypeT } from "@/services/domain/Type";
+import { YjsT } from "@/services/external/Yjs";
+import { TypePickerT } from "@/services/ui/TypePicker";
+import EditorBuffer from "@/ui/EditorBuffer";
+import { Effect } from "effect";
+import { waitFor } from "solid-testing-library";
+import { describe, expect, it } from "vitest";
+import { Given, render, runtime, Then, When } from "./bdd";
+
+describe("TypePicker in Title", () => {
+  describe("Opening the picker", () => {
+    it("shows picker popup when # is typed in title", async () => {
+      await Effect.gen(function* () {
+        const { bufferId } = yield* Given.A_BUFFER_WITH_CHILDREN("Root node", [
+          { text: "Child" },
+        ]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_TITLE(bufferId);
+        yield* When.USER_PRESSES("#");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeTruthy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Selecting a type", () => {
+    it("applies type to title node and removes # text when Enter is pressed", async () => {
+      await Effect.gen(function* () {
+        const uniqueTypeName = `TitleType_${Date.now()}`;
+        const TypePicker = yield* TypePickerT;
+        const typeId = yield* TypePicker.createType(uniqueTypeName);
+
+        const { bufferId, rootNodeId } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "My Title",
+          [{ text: "Child" }],
+        );
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_TITLE(bufferId);
+
+        // Type # to open picker
+        yield* When.USER_PRESSES("#");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+              const buttons = picker.querySelectorAll("button");
+              if (buttons.length === 0) throw new Error("Types not loaded yet");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Type "title" to filter (matches our unique TitleType_xxx name)
+        yield* When.USER_PRESSES("title");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const Yjs = runtime.runSync(YjsT);
+              const text = Yjs.getText(rootNodeId).toString();
+              if (!text.includes("#title"))
+                throw new Error("Text not updated: " + text);
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker closed unexpectedly");
+              const buttons = picker.querySelectorAll("button");
+              const hasType = Array.from(buttons).some((btn) =>
+                btn.textContent?.includes(uniqueTypeName),
+              );
+              if (!hasType)
+                throw new Error(`${uniqueTypeName} not showing in filtered list`);
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Enter to select the first filtered type
+        yield* When.USER_PRESSES("{Enter}");
+
+        // Type should be applied to the root node (title)
+        yield* Effect.promise(() =>
+          waitFor(
+            async () => {
+              const Type = await TypeT.pipe(runtime.runPromise);
+              const hasType = await Type.hasType(rootNodeId, typeId).pipe(
+                runtime.runPromise,
+              );
+              expect(hasType).toBe(true);
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // # text should be removed, title should be back to original
+        yield* Then.NODE_HAS_TEXT(rootNodeId, "My Title");
+
+        // Picker should be closed
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeFalsy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+
+    it("creates and applies new type from title", async () => {
+      await Effect.gen(function* () {
+        const { bufferId, rootNodeId } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "My Title",
+          [{ text: "Child" }],
+        );
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_TITLE(bufferId);
+        yield* When.USER_PRESSES("#newtitletag");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Enter to create and select
+        yield* When.USER_PRESSES("{Enter}");
+
+        // Check that a new type was created under System.TYPES
+        yield* Effect.promise(() =>
+          waitFor(
+            async () => {
+              const Node = await NodeT.pipe(runtime.runPromise);
+              const Yjs = await YjsT.pipe(runtime.runPromise);
+              const typeChildren = await Node.getNodeChildren(System.TYPES).pipe(
+                runtime.runPromise,
+              );
+              const typeNames = typeChildren.map((id) =>
+                Yjs.getText(id).toString(),
+              );
+              expect(typeNames).toContain("newtitletag");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // # text should be removed
+        yield* Then.NODE_HAS_TEXT(rootNodeId, "My Title");
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Closing the picker", () => {
+    it("closes picker when Escape is pressed in title", async () => {
+      await Effect.gen(function* () {
+        const { bufferId } = yield* Given.A_BUFFER_WITH_CHILDREN("My Title", [
+          { text: "Child" },
+        ]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_TITLE(bufferId);
+        yield* When.USER_PRESSES("#test");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Escape
+        yield* When.USER_PRESSES("{Escape}");
+
+        // Picker should be closed
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeFalsy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Type display", () => {
+    it("displays types applied to title in TypeList", async () => {
+      await Effect.gen(function* () {
+        const TypePicker = yield* TypePickerT;
+        const typeId = yield* TypePicker.createType("TitleTag");
+
+        const { bufferId, rootNodeId } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "My Title",
+          [{ text: "Child" }],
+        );
+
+        // Apply the type to the root node (title)
+        yield* TypePicker.applyType(rootNodeId, typeId);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        // Type badge should be visible below title
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const allText = document.body.textContent;
+              expect(allText).toContain("TitleTag");
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+});

--- a/apps/web/src/__tests__/TypePicker.browser.spec.tsx
+++ b/apps/web/src/__tests__/TypePicker.browser.spec.tsx
@@ -1,0 +1,401 @@
+import "@/index.css";
+import { Id, System } from "@/schema";
+import { NodeT } from "@/services/domain/Node";
+import { TypeT } from "@/services/domain/Type";
+import { YjsT } from "@/services/external/Yjs";
+import { TypePickerT } from "@/services/ui/TypePicker";
+import EditorBuffer from "@/ui/EditorBuffer";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { Given, render, runtime, Then, When } from "./bdd";
+import { waitFor } from "solid-testing-library";
+
+describe("TypePicker", () => {
+  describe("Opening the picker", () => {
+    it("shows picker popup when # is typed", async () => {
+      await Effect.gen(function* () {
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+        yield* When.USER_PRESSES("#");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeTruthy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Filtering types", () => {
+    it("filters types as user types after #", async () => {
+      await Effect.gen(function* () {
+        // Create some types first
+        const TypePicker = yield* TypePickerT;
+        yield* TypePicker.createType("Page");
+        yield* TypePicker.createType("Project");
+
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+        yield* When.USER_PRESSES("#pa");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeTruthy();
+              // Should show "Page" but not "Project"
+              const items = picker!.querySelectorAll("button");
+              const texts = Array.from(items).map((btn) => btn.textContent);
+              expect(texts.some((t) => t?.includes("Page"))).toBe(true);
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+
+    it("shows Create option when no exact match", async () => {
+      await Effect.gen(function* () {
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+        yield* When.USER_PRESSES("#newtype");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeTruthy();
+              const createOption = picker!.querySelector("button");
+              expect(createOption?.textContent).toContain("Create");
+              expect(createOption?.textContent).toContain("#newtype");
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Selecting a type", () => {
+    it("applies type and removes # text when Enter is pressed", async () => {
+      await Effect.gen(function* () {
+        // Create a type with unique name to avoid conflicts with other test runs
+        const uniqueTypeName = `TestType_${Date.now()}`;
+        const TypePicker = yield* TypePickerT;
+        const typeId = yield* TypePicker.createType(uniqueTypeName);
+
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+        const childNodeId = childNodeIds[0];
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+
+        // Type # to open picker
+        yield* When.USER_PRESSES("#");
+
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+              const buttons = picker.querySelectorAll("button");
+              if (buttons.length === 0) throw new Error("Types not loaded yet");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Type "test" to filter (matches our unique TestType_xxx name)
+        yield* When.USER_PRESSES("test");
+
+        // Wait for the text to update AND picker to show filtered result
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const Yjs = runtime.runSync(YjsT);
+              const text = Yjs.getText(childNodeId).toString();
+              if (!text.includes("#test")) throw new Error("Text not updated: " + text);
+              // Verify the picker shows our unique type
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker closed unexpectedly");
+              const buttons = picker.querySelectorAll("button");
+              const hasType = Array.from(buttons).some((btn) =>
+                btn.textContent?.includes(uniqueTypeName),
+              );
+              if (!hasType) throw new Error(`${uniqueTypeName} not showing in filtered list`);
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Enter to select the first filtered type
+        yield* When.USER_PRESSES("{Enter}");
+
+        // Type should be applied
+        yield* Effect.promise(() =>
+          waitFor(
+            async () => {
+              const Type = await TypeT.pipe(runtime.runPromise);
+              const hasType = await Type.hasType(childNodeId, typeId).pipe(
+                runtime.runPromise,
+              );
+              expect(hasType).toBe(true);
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // # text should be removed
+        yield* Then.NODE_HAS_TEXT(childNodeId, "Hello");
+
+        // Picker should be closed
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeFalsy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+
+    it("creates and applies new type when selecting Create option", async () => {
+      await Effect.gen(function* () {
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+        const childNodeId = childNodeIds[0];
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+        yield* When.USER_PRESSES("#mytag");
+
+        // Wait for picker
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Enter to create and select
+        yield* When.USER_PRESSES("{Enter}");
+
+        // Check that a new type was created under System.TYPES
+        yield* Effect.promise(() =>
+          waitFor(
+            async () => {
+              const Node = await NodeT.pipe(runtime.runPromise);
+              const Yjs = await YjsT.pipe(runtime.runPromise);
+              const typeChildren = await Node.getNodeChildren(System.TYPES).pipe(
+                runtime.runPromise,
+              );
+              const typeNames = typeChildren.map((id) =>
+                Yjs.getText(id).toString(),
+              );
+              expect(typeNames).toContain("mytag");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // # text should be removed
+        yield* Then.NODE_HAS_TEXT(childNodeId, "Hello");
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Closing the picker", () => {
+    it("closes picker when Escape is pressed", async () => {
+      await Effect.gen(function* () {
+        const { bufferId, childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Hello" }],
+        );
+
+        const firstChildBlockId = Id.makeBlockId(bufferId, childNodeIds[0]);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        yield* When.USER_CLICKS_BLOCK(firstChildBlockId);
+        yield* When.USER_PRESSES("#test");
+
+        // Wait for picker to show
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              if (!picker) throw new Error("Picker not found");
+            },
+            { timeout: 2000 },
+          ),
+        );
+
+        // Press Escape
+        yield* When.USER_PRESSES("{Escape}");
+
+        // Picker should be closed
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const picker = document.querySelector("[data-testid='type-picker']");
+              expect(picker).toBeFalsy();
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+
+  describe("Type display", () => {
+    it("displays applied types below title", async () => {
+      await Effect.gen(function* () {
+        // Create a type and apply it to the root node
+        const TypePicker = yield* TypePickerT;
+        const typeId = yield* TypePicker.createType("Important");
+
+        const { bufferId, rootNodeId } = yield* Given.A_BUFFER_WITH_CHILDREN(
+          "Root node",
+          [{ text: "Child" }],
+        );
+
+        // Apply the type to the root node
+        yield* TypePicker.applyType(rootNodeId, typeId);
+
+        render(() => <EditorBuffer bufferId={bufferId} />);
+
+        // Type badge should be visible
+        yield* Effect.promise(() =>
+          waitFor(
+            () => {
+              const allText = document.body.textContent;
+              expect(allText).toContain("Important");
+            },
+            { timeout: 2000 },
+          ),
+        );
+      }).pipe(runtime.runPromise);
+    });
+  });
+});
+
+describe("TypePickerT Service", () => {
+  it("getAvailableTypes returns children of Types node", async () => {
+    await Effect.gen(function* () {
+      const TypePicker = yield* TypePickerT;
+
+      // Create some types
+      yield* TypePicker.createType("TestType1");
+      yield* TypePicker.createType("TestType2");
+
+      const types = yield* TypePicker.getAvailableTypes();
+
+      const names = types.map((t) => t.name);
+      expect(names).toContain("TestType1");
+      expect(names).toContain("TestType2");
+    }).pipe(runtime.runPromise);
+  });
+
+  it("filterTypes matches case-insensitively", async () => {
+    await Effect.gen(function* () {
+      const TypePicker = yield* TypePickerT;
+
+      const types = [
+        { id: "a" as Id.Node, name: "Apple" },
+        { id: "b" as Id.Node, name: "Banana" },
+        { id: "c" as Id.Node, name: "apricot" },
+      ];
+
+      const filtered = TypePicker.filterTypes(types, "ap");
+
+      expect(filtered.length).toBe(2);
+      expect(filtered.map((t) => t.name)).toContain("Apple");
+      expect(filtered.map((t) => t.name)).toContain("apricot");
+    }).pipe(runtime.runPromise);
+  });
+
+  it("createType adds child to Types node", async () => {
+    await Effect.gen(function* () {
+      const TypePicker = yield* TypePickerT;
+      const Node = yield* NodeT;
+      const Yjs = yield* YjsT;
+
+      const typeId = yield* TypePicker.createType("NewType");
+
+      // Should be a child of System.TYPES
+      const typeChildren = yield* Node.getNodeChildren(System.TYPES);
+      expect(typeChildren).toContain(typeId);
+
+      // Should have the correct text
+      const ytext = Yjs.getText(typeId);
+      expect(ytext.toString()).toBe("NewType");
+    }).pipe(runtime.runPromise);
+  });
+
+  it("applyType adds type to node", async () => {
+    await Effect.gen(function* () {
+      const TypePicker = yield* TypePickerT;
+      const Type = yield* TypeT;
+
+      // Create a node
+      const { childNodeIds } = yield* Given.A_BUFFER_WITH_CHILDREN("Root", [
+        { text: "Test" },
+      ]);
+
+      const nodeId = childNodeIds[0];
+      const typeId = yield* TypePicker.createType("TestType");
+
+      // Apply type
+      yield* TypePicker.applyType(nodeId, typeId);
+
+      // Check it was applied
+      const hasType = yield* Type.hasType(nodeId, typeId);
+      expect(hasType).toBe(true);
+    }).pipe(runtime.runPromise);
+  });
+});

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -81,6 +81,9 @@ tfoot th {
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
+  --type-badge: oklch(0.92 0.05 145);
+  --type-badge-foreground: oklch(0.35 0.12 145);
+
   --radius: 0.5rem;
   --max-line-width: 50rem;
   --spacing: 0.25rem;
@@ -162,6 +165,8 @@ tfoot th {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-type-badge: var(--type-badge);
+  --color-type-badge-foreground: var(--type-badge-foreground);
 
   --shadow-daiichi:
     0px 0px 0px 1px

--- a/apps/web/src/livestore/events.ts
+++ b/apps/web/src/livestore/events.ts
@@ -157,3 +157,22 @@ export const tupleDeleted = Events.synced({
 });
 
 export type TupleDeleted = typeof tupleDeleted;
+
+// Batch node reordering event for smooth multi-block animations
+export const nodesReordered = Events.synced({
+  name: "v1.NodesReordered",
+  schema: Schema.Struct({
+    timestamp: Schema.Number,
+    data: Schema.Struct({
+      moves: Schema.Array(
+        Schema.Struct({
+          nodeId: Schema.String,
+          newParentId: Schema.String,
+          position: Schema.String,
+        }),
+      ),
+    }),
+  }),
+});
+
+export type NodesReordered = typeof nodesReordered;

--- a/apps/web/src/livestore/schema.ts
+++ b/apps/web/src/livestore/schema.ts
@@ -461,6 +461,16 @@ const materializers = State.SQLite.materializers(events, {
     const deleteTupleOp = tables.tuples.delete().where({ id: data.tupleId });
     return [deleteMembersOp, deleteTupleOp];
   },
+  "v1.NodesReordered": ({ data }) => {
+    return data.moves.map((move) =>
+      parentLinks
+        .update({
+          parentId: move.newParentId,
+          position: move.position,
+        })
+        .where({ childId: move.nodeId }),
+    );
+  },
 });
 
 const state = State.SQLite.makeState({ tables, materializers });

--- a/apps/web/src/runtime.ts
+++ b/apps/web/src/runtime.ts
@@ -19,6 +19,7 @@ import { registerBuiltInTypes } from "./services/ui/BlockType/definitions";
 import { BufferLive } from "./services/ui/Buffer";
 import { TitleLive } from "./services/ui/Title";
 import { NavigationLive } from "./services/ui/Navigation";
+import { TypePickerLive } from "./services/ui/TypePicker";
 import { WindowLive } from "./services/ui/Window";
 
 registerBuiltInTypes();
@@ -58,6 +59,7 @@ const BrowserLayer = pipe(
   NavigationLive,
   Layer.provideMerge(DataPortLive),
   Layer.provideMerge(BootstrapLive),
+  Layer.provideMerge(TypePickerLive),
   Layer.provideMerge(TitleLive),
   Layer.provideMerge(BlockLive),
   Layer.provideMerge(BufferLive),

--- a/apps/web/src/schema/system.ts
+++ b/apps/web/src/schema/system.ts
@@ -74,6 +74,11 @@ export const System = {
    * Calendar node for time-based organization. URL shortcut: /calendar
    */
   CALENDAR: "workspace:calendar" as Id.Node,
+
+  /**
+   * Types node for user-created types. URL shortcut: /types
+   */
+  TYPES: "workspace:types" as Id.Node,
 } as const;
 
 export type SystemId = (typeof System)[keyof typeof System];

--- a/apps/web/src/services/domain/Bootstrap/index.ts
+++ b/apps/web/src/services/domain/Bootstrap/index.ts
@@ -201,6 +201,14 @@ const ensureSystemNodes = () =>
       yield* createRootNode(System.CALENDAR, rootPos);
       yield* setNodeText(System.CALENDAR, "Calendar");
     }
+
+    // === Types (root node for user-created types) ===
+    rootPos = nextPosition(rootPos);
+    const typesExists = yield* nodeExists(System.TYPES);
+    if (!typesExists) {
+      yield* createRootNode(System.TYPES, rootPos);
+      yield* setNodeText(System.TYPES, "Types");
+    }
   });
 
 export const BootstrapLive = Layer.effect(

--- a/apps/web/src/services/domain/Node/index.ts
+++ b/apps/web/src/services/domain/Node/index.ts
@@ -13,6 +13,7 @@ import { get } from "./get";
 import { getNodeChildren } from "./getNodeChildren";
 import { getParent } from "./getParent";
 import { insertNode, InsertNodeArgs } from "./insertNode";
+import { moveNodes, MoveNodesArgs } from "./moveNodes";
 import { subscribe } from "./subscribe";
 import { subscribeChildren } from "./subscribeChildren";
 import { subscribeEither } from "./subscribeEither";
@@ -68,6 +69,11 @@ export class NodeT extends Context.Tag("NodeT")<
      * Deletes a node and all its descendants.
      */
     deleteNode: (nodeId: Id.Node) => Effect.Effect<void>;
+    /**
+     * Moves multiple nodes in a single atomic operation.
+     * All nodes are moved relative to the same sibling, maintaining their order.
+     */
+    moveNodes: (args: MoveNodesArgs) => Effect.Effect<void, NodeNotFoundError>;
   }
 >() {}
 
@@ -89,8 +95,10 @@ export const NodeLive = Layer.effect(
       getNodeChildren: withContext(getNodeChildren)(context),
       get: withContext(get)(context),
       deleteNode: withContext(deleteNode)(context),
+      moveNodes: withContext(moveNodes)(context),
     };
   }),
 );
 
 export type { InsertNodeArgs } from "./insertNode";
+export type { MoveNodesArgs } from "./moveNodes";

--- a/apps/web/src/services/domain/Node/moveNodes.ts
+++ b/apps/web/src/services/domain/Node/moveNodes.ts
@@ -1,0 +1,130 @@
+import { events, tables } from "@/livestore/schema";
+import { Id } from "@/schema";
+import { StoreT } from "@/services/external/Store";
+import { Effect } from "effect";
+import { generateKeyBetween } from "fractional-indexing";
+import { NodeNotFoundError } from "../errors";
+
+export type MoveNodesArgs = {
+  nodeIds: readonly Id.Node[];
+  parentId: Id.Node;
+  insert: "before" | "after";
+  siblingId: Id.Node;
+};
+
+/**
+ * Get the position of a sibling node
+ */
+const getSiblingPosition = (siblingId: Id.Node) =>
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const link = yield* Store.query(
+      tables.parentLinks
+        .select()
+        .where({ childId: siblingId })
+        .first({ fallback: () => null }),
+    );
+    if (!link) {
+      return yield* Effect.fail(new NodeNotFoundError({ nodeId: siblingId }));
+    }
+    return link.position;
+  });
+
+/**
+ * Get the next sibling's position (the one after a given position)
+ */
+const getNextSiblingPosition = (parentId: Id.Node, afterPosition: string) =>
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const nextSibling = yield* Store.query(
+      tables.parentLinks
+        .select()
+        .where({
+          parentId,
+          position: { op: ">", value: afterPosition },
+        })
+        .orderBy("position", "asc")
+        .first({ fallback: () => null }),
+    );
+    return nextSibling?.position ?? null;
+  });
+
+/**
+ * Get the previous sibling's position (the one before a given position)
+ */
+const getPrevSiblingPosition = (parentId: Id.Node, beforePosition: string) =>
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const prevSibling = yield* Store.query(
+      tables.parentLinks
+        .select()
+        .where({
+          parentId,
+          position: { op: "<", value: beforePosition },
+        })
+        .orderBy("position", "desc")
+        .first({ fallback: () => null }),
+    );
+    return prevSibling?.position ?? null;
+  });
+
+/**
+ * Moves multiple nodes in a single atomic operation.
+ * All nodes are moved relative to the same sibling, maintaining their relative order.
+ */
+export const moveNodes = (args: MoveNodesArgs) =>
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const { nodeIds, parentId, insert, siblingId } = args;
+
+    if (nodeIds.length === 0) return;
+
+    // Get the reference sibling's position
+    const siblingPos = yield* getSiblingPosition(siblingId);
+
+    const moves: Array<{ nodeId: string; newParentId: string; position: string }> = [];
+
+    if (insert === "before") {
+      // For "before": process in forward order
+      // Each node slots between the previous insertion and the sibling
+      let prevPos = yield* getPrevSiblingPosition(parentId, siblingPos);
+
+      for (const nodeId of nodeIds) {
+        const position = generateKeyBetween(prevPos, siblingPos);
+        moves.push({
+          nodeId,
+          newParentId: parentId,
+          position,
+        });
+        // Next node will be inserted after this one
+        prevPos = position;
+      }
+    } else {
+      // For "after": process in reverse order
+      // Each node slots between the sibling and the next position
+      let nextPos = yield* getNextSiblingPosition(parentId, siblingPos);
+
+      for (let i = nodeIds.length - 1; i >= 0; i--) {
+        const nodeId = nodeIds[i]!;
+        const position = generateKeyBetween(siblingPos, nextPos);
+        moves.push({
+          nodeId,
+          newParentId: parentId,
+          position,
+        });
+        // Next node (processed earlier in array) will slot between sibling and this one
+        nextPos = position;
+      }
+
+      // Reverse to maintain original order in the event
+      moves.reverse();
+    }
+
+    // Single commit with all moves
+    yield* Store.commit(
+      events.nodesReordered({
+        timestamp: Date.now(),
+        data: { moves },
+      }),
+    );
+  });

--- a/apps/web/src/services/ui/Navigation/index.ts
+++ b/apps/web/src/services/ui/Navigation/index.ts
@@ -9,6 +9,7 @@ const URL_SHORTCUTS: Record<string, Id.Node> = {
   "/inbox": System.INBOX,
   "/box": System.THE_BOX,
   "/calendar": System.CALENDAR,
+  "/types": System.TYPES,
 };
 
 const parseNodeIdFromPath = (path: string): Option.Option<Id.Node> => {
@@ -28,6 +29,7 @@ const NODE_TO_PATH: Record<string, string> = {
   [System.INBOX]: "/inbox",
   [System.THE_BOX]: "/box",
   [System.CALENDAR]: "/calendar",
+  [System.TYPES]: "/types",
 };
 
 const makePathFromNodeId = (nodeId: Id.Node | null): string => {

--- a/apps/web/src/services/ui/TypePicker/index.ts
+++ b/apps/web/src/services/ui/TypePicker/index.ts
@@ -1,0 +1,152 @@
+import { tables } from "@/livestore/schema";
+import { Id, System } from "@/schema";
+import { NodeT } from "@/services/domain/Node";
+import { TypeT } from "@/services/domain/Type";
+import { StoreT } from "@/services/external/Store";
+import { YjsT } from "@/services/external/Yjs";
+import { withContext } from "@/utils";
+import { Context, Effect, Layer } from "effect";
+
+/** Available type with ID and display name */
+export interface AvailableType {
+  id: Id.Node;
+  name: string;
+}
+
+/** System types that should be filtered out from user-facing type picker */
+const SYSTEM_TYPE_IDS = new Set<Id.Node>([
+  System.LIST_ELEMENT,
+  System.CHECKBOX,
+  System.RENDERING_TYPE,
+  System.BOOLEAN,
+  System.TRUE,
+  System.FALSE,
+  System.TUPLE_TYPE,
+  System.IS_CHECKED,
+]);
+
+/** Check if a type ID is a system type */
+export const isSystemType = (typeId: Id.Node): boolean =>
+  SYSTEM_TYPE_IDS.has(typeId);
+
+export class TypePickerT extends Context.Tag("TypePickerT")<
+  TypePickerT,
+  {
+    /**
+     * Get all user-defined types (children of System.TYPES node).
+     */
+    getAvailableTypes: () => Effect.Effect<readonly AvailableType[]>;
+    /**
+     * Filter types by search query (case-insensitive substring match).
+     */
+    filterTypes: (
+      types: readonly AvailableType[],
+      query: string,
+    ) => readonly AvailableType[];
+    /**
+     * Create a new type under System.TYPES and return its ID.
+     */
+    createType: (name: string) => Effect.Effect<Id.Node>;
+    /**
+     * Apply a type to a node.
+     */
+    applyType: (nodeId: Id.Node, typeId: Id.Node) => Effect.Effect<void>;
+  }
+>() {}
+
+const getAvailableTypes = () =>
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const Yjs = yield* YjsT;
+
+    // Get all children of the Types node
+    const childIds = yield* Store.query(
+      tables.parentLinks
+        .select("childId")
+        .where("parentId", "=", System.TYPES)
+        .orderBy("position", "asc"),
+    );
+
+    // Get names for each type from Yjs
+    const types: AvailableType[] = [];
+    for (const id of childIds as Id.Node[]) {
+      const yText = Yjs.getText(id);
+      const name = yText.toString();
+      types.push({ id, name });
+    }
+
+    yield* Effect.logDebug("[TypePicker.getAvailableTypes] Fetched types").pipe(
+      Effect.annotateLogs({
+        count: types.length,
+        types: types.map((t) => ({ id: t.id, name: t.name })),
+      }),
+    );
+
+    return types;
+  });
+
+const filterTypes = (
+  types: readonly AvailableType[],
+  query: string,
+): readonly AvailableType[] => {
+  if (!query) return types;
+  const lowerQuery = query.toLowerCase();
+  return types.filter((type) => type.name.toLowerCase().includes(lowerQuery));
+};
+
+const createType = (name: string) =>
+  Effect.gen(function* () {
+    const Node = yield* NodeT;
+    const Yjs = yield* YjsT;
+
+    // Create a new node under System.TYPES
+    const typeId = yield* Node.insertNode({
+      parentId: System.TYPES,
+      insert: "after",
+    });
+
+    // Set the text content
+    const yText = Yjs.getText(typeId);
+    yText.insert(0, name);
+
+    yield* Effect.logDebug("[TypePicker.createType] Created new type").pipe(
+      Effect.annotateLogs({ typeId, name }),
+    );
+
+    return typeId;
+  }).pipe(Effect.orDie);
+
+const applyType = (nodeId: Id.Node, typeId: Id.Node) =>
+  Effect.gen(function* () {
+    const Type = yield* TypeT;
+    yield* Effect.logDebug("[TypePicker.applyType] Applying type to node").pipe(
+      Effect.annotateLogs({ nodeId, typeId }),
+    );
+    yield* Type.addType(nodeId, typeId);
+    yield* Effect.logDebug("[TypePicker.applyType] Type applied successfully").pipe(
+      Effect.annotateLogs({ nodeId, typeId }),
+    );
+  });
+
+export const TypePickerLive = Layer.effect(
+  TypePickerT,
+  Effect.gen(function* () {
+    const Store = yield* StoreT;
+    const Yjs = yield* YjsT;
+    const Node = yield* NodeT;
+    const Type = yield* TypeT;
+
+    const context = Context.make(StoreT, Store).pipe(
+      Context.add(YjsT, Yjs),
+      Context.add(NodeT, Node),
+      Context.add(TypeT, Type),
+    );
+
+    return {
+      getAvailableTypes: withContext(getAvailableTypes)(context),
+      filterTypes,
+      createType: withContext(createType)(context),
+      applyType: withContext(applyType)(context),
+    };
+  }),
+);

--- a/apps/web/src/services/ui/TypePicker/index.ts
+++ b/apps/web/src/services/ui/TypePicker/index.ts
@@ -60,6 +60,7 @@ const getAvailableTypes = () =>
     const Yjs = yield* YjsT;
 
     // Get all children of the Types node
+    // When selecting a single column, LiveStore returns an array of values
     const childIds = yield* Store.query(
       tables.parentLinks
         .select("childId")

--- a/apps/web/src/ui/Block.tsx
+++ b/apps/web/src/ui/Block.tsx
@@ -8,7 +8,7 @@ import { BlockT } from "@/services/ui/Block";
 import * as BlockType from "@/services/ui/BlockType";
 import { BufferT } from "@/services/ui/Buffer";
 import { NavigationT } from "@/services/ui/Navigation";
-import { TypePickerT } from "@/services/ui/TypePicker";
+import { isSystemType, TypePickerT } from "@/services/ui/TypePicker";
 import { WindowT } from "@/services/ui/Window";
 import { bindStreamToStore } from "@/utils/bindStreamToStore";
 import {
@@ -31,6 +31,7 @@ import TextEditor, {
   type EnterKeyInfo,
   type SelectionInfo,
 } from "./TextEditor";
+import TypeBadge from "./TypeBadge";
 import { TypePicker } from "./TypePicker";
 
 interface BlockProps {
@@ -140,6 +141,7 @@ export default function Block({ blockId }: BlockProps) {
   });
 
   const hasType = (typeId: Id.Node) => activeTypes().includes(typeId);
+  const userTypes = () => activeTypes().filter((typeId) => !isSystemType(typeId));
 
   const getActiveDefinitions = () =>
     activeTypes()
@@ -887,6 +889,9 @@ export default function Block({ blockId }: BlockProps) {
             fallback={
               <p class="font-[family-name:var(--font-sans)] text-[length:var(--text-block)] leading-[var(--text-block--line-height)] min-h-[var(--text-block--line-height)] whitespace-break-spaces">
                 {textContent() || "\u00A0"}
+                <For each={userTypes()}>
+                  {(typeId) => <TypeBadge typeId={typeId} nodeId={nodeId} />}
+                </For>
               </p>
             }
           >

--- a/apps/web/src/ui/Block.tsx
+++ b/apps/web/src/ui/Block.tsx
@@ -8,6 +8,7 @@ import { BlockT } from "@/services/ui/Block";
 import * as BlockType from "@/services/ui/BlockType";
 import { BufferT } from "@/services/ui/Buffer";
 import { NavigationT } from "@/services/ui/Navigation";
+import { TypePickerT } from "@/services/ui/TypePicker";
 import { WindowT } from "@/services/ui/Window";
 import { bindStreamToStore } from "@/utils/bindStreamToStore";
 import {
@@ -30,6 +31,7 @@ import TextEditor, {
   type EnterKeyInfo,
   type SelectionInfo,
 } from "./TextEditor";
+import { TypePicker } from "./TypePicker";
 
 interface BlockProps {
   blockId: Id.Block;
@@ -103,6 +105,22 @@ export default function Block({ blockId }: BlockProps) {
 
   const [textContent, setTextContent] = createSignal(ytext.toString());
   const [activeTypes, setActiveTypes] = createSignal<readonly Id.Node[]>([]);
+
+  // Type picker state
+  const [pickerState, setPickerState] = createSignal<{
+    visible: boolean;
+    position: { x: number; y: number };
+    from: number;
+  } | null>(null);
+
+  const getPickerQuery = () => {
+    const state = pickerState();
+    if (!state) return "";
+    const text = textContent();
+    const cursorPos = store.selection?.head ?? text.length;
+    // Extract text after "#" (from + 1) up to cursor
+    return text.slice(state.from + 1, cursorPos);
+  };
 
   // Flag to prevent blur handler from clearing state during block movement
   let isMoving = false;
@@ -668,9 +686,135 @@ export default function Block({ blockId }: BlockProps) {
     return true;
   };
 
+  // Type picker handlers
+  const handleTypePickerOpen = (
+    position: { x: number; y: number },
+    from: number,
+  ) => {
+    setPickerState({ visible: true, position, from });
+  };
+
+  const handleTypePickerClose = () => {
+    setPickerState(null);
+  };
+
+  const handleTypePickerSelect = (typeId: Id.Node) => {
+    const state = pickerState();
+    if (!state) return;
+
+    runtime.runFork(
+      Effect.gen(function* () {
+        const TypePicker = yield* TypePickerT;
+        const Buffer = yield* BufferT;
+
+        yield* TypePicker.applyType(nodeId, typeId);
+
+        const cursorPos = store.selection?.head ?? ytext.length;
+        const deleteLength = cursorPos - state.from;
+        if (deleteLength > 0) {
+          ytext.delete(state.from, deleteLength);
+        }
+
+        const [bufferId] = yield* Id.parseBlockId(blockId);
+        yield* Buffer.setSelection(
+          bufferId,
+          Option.some({
+            anchor: { nodeId },
+            anchorOffset: state.from,
+            focus: { nodeId },
+            focusOffset: state.from,
+            goalX: null,
+            goalLine: null,
+            assoc: 0,
+          }),
+        );
+
+        yield* Effect.logDebug("[Block] Type selected via picker").pipe(
+          Effect.annotateLogs({ blockId, nodeId, typeId }),
+        );
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("[Block] Type picker select failed").pipe(
+            Effect.annotateLogs({ blockId, nodeId, typeId, error: String(err) }),
+          ),
+        ),
+        Effect.catchAll(() => Effect.void),
+      ),
+    );
+
+    setPickerState(null);
+  };
+
+  const handleTypePickerCreate = (name: string) => {
+    const state = pickerState();
+    if (!state) return;
+
+    runtime.runFork(
+      Effect.gen(function* () {
+        const TypePicker = yield* TypePickerT;
+        const Buffer = yield* BufferT;
+
+        const typeId = yield* TypePicker.createType(name);
+        yield* TypePicker.applyType(nodeId, typeId);
+
+        const cursorPos = store.selection?.head ?? ytext.length;
+        const deleteLength = cursorPos - state.from;
+        if (deleteLength > 0) {
+          ytext.delete(state.from, deleteLength);
+        }
+
+        const [bufferId] = yield* Id.parseBlockId(blockId);
+        yield* Buffer.setSelection(
+          bufferId,
+          Option.some({
+            anchor: { nodeId },
+            anchorOffset: state.from,
+            focus: { nodeId },
+            focusOffset: state.from,
+            goalX: null,
+            goalLine: null,
+            assoc: 0,
+          }),
+        );
+
+        yield* Effect.logDebug("[Block] Type created via picker").pipe(
+          Effect.annotateLogs({ blockId, nodeId, typeId, name }),
+        );
+      }).pipe(
+        Effect.tapError((err) =>
+          Effect.logError("[Block] Type picker create failed").pipe(
+            Effect.annotateLogs({ blockId, nodeId, name, error: String(err) }),
+          ),
+        ),
+        Effect.catchAll(() => Effect.void),
+      ),
+    );
+
+    setPickerState(null);
+  };
+
   const handleAction = (action: EditorAction): boolean | void =>
     Match.value(action).pipe(
-      Match.tag("Enter", ({ info }) => handleEnter(info)),
+      Match.tag("Enter", ({ info }) => {
+        // If picker is open, select the current item
+        if (pickerState()) {
+          const query = getPickerQuery();
+          const availableTypes = runtime.runSync(
+            Effect.gen(function* () {
+              const TypePicker = yield* TypePickerT;
+              const types = yield* TypePicker.getAvailableTypes();
+              return TypePicker.filterTypes(types, query);
+            }),
+          );
+          if (availableTypes.length > 0) {
+            handleTypePickerSelect(availableTypes[0]!.id);
+          } else if (query) {
+            handleTypePickerCreate(query);
+          }
+          return true;
+        }
+        return handleEnter(info);
+      }),
       Match.tag("Tab", () => handleTab()),
       Match.tag("ShiftTab", () => handleShiftTab()),
       Match.tag("BackspaceAtStart", () => handleBackspaceAtStart()),
@@ -688,13 +832,27 @@ export default function Block({ blockId }: BlockProps) {
         handleSelectionChange(selection),
       ),
       Match.tag("Blur", () => handleBlur()),
-      Match.tag("Escape", () => enterBlockSelectionMode()),
+      Match.tag("Escape", () => {
+        // If picker is open, close it instead of entering block selection
+        if (pickerState()) {
+          handleTypePickerClose();
+          return;
+        }
+        enterBlockSelectionMode();
+      }),
       Match.tag("ZoomIn", () => handleZoomIn()),
       Match.tag("BlockSelect", () => enterBlockSelectionMode()),
       Match.tag("Move", ({ action: moveAction }) => handleMove(moveAction)),
       Match.tag("TypeTrigger", ({ typeId, trigger }) =>
         handleTypeTrigger(typeId, trigger),
       ),
+      Match.tag("TypePickerOpen", ({ position, from }) =>
+        handleTypePickerOpen(position, from),
+      ),
+      Match.tag("TypePickerUpdate", () => {
+        // Query is computed reactively from textContent and selection
+      }),
+      Match.tag("TypePickerClose", () => handleTypePickerClose()),
       Match.exhaustive,
     );
 
@@ -760,6 +918,19 @@ export default function Block({ blockId }: BlockProps) {
           </For>
         </TransitionGroup>
       </div>
+
+      <Show when={pickerState()}>
+        {(state) => (
+          <TypePicker
+            position={state().position}
+            query={getPickerQuery()}
+            nodeId={nodeId}
+            onSelect={handleTypePickerSelect}
+            onCreate={handleTypePickerCreate}
+            onClose={handleTypePickerClose}
+          />
+        )}
+      </Show>
     </div>
   );
 }

--- a/apps/web/src/ui/Block.tsx
+++ b/apps/web/src/ui/Block.tsx
@@ -905,6 +905,8 @@ export default function Block({ blockId }: BlockProps) {
                 modelSelection: store.selection,
               })}
               selection={store.selection}
+              inlineTypes={userTypes()}
+              inlineTypesNodeId={nodeId}
             />
           </Show>
         </div>

--- a/apps/web/src/ui/EditorBuffer.tsx
+++ b/apps/web/src/ui/EditorBuffer.tsx
@@ -11,6 +11,7 @@ import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { TransitionGroup } from "solid-transition-group";
 import Block from "./Block";
 import Title from "./Title";
+import TypeList from "./TypeList";
 
 const isMac = navigator.platform.toUpperCase().includes("MAC");
 
@@ -890,6 +891,7 @@ export default function EditorBuffer({ bufferId }: EditorBufferProps) {
           <>
             <header class="mx-auto max-w-[var(--max-line-width)] w-full border-b-[1.5px] border-foreground-lighter pb-3 pt-7">
               <Title bufferId={bufferId} nodeId={nodeId} />
+              <TypeList nodeId={nodeId} />
             </header>
             <div data-testid="editor-body" class="flex-1 flex flex-col pt-4">
               <div class="mx-auto flex flex-col gap-1.5 max-w-[var(--max-line-width)] w-full">

--- a/apps/web/src/ui/Sidebar/SidebarNav.tsx
+++ b/apps/web/src/ui/Sidebar/SidebarNav.tsx
@@ -7,13 +7,14 @@ import { For } from "solid-js";
 interface NavItem {
   label: string;
   nodeId: Id.Node;
-  icon: "inbox" | "box" | "calendar";
+  icon: "inbox" | "box" | "calendar" | "tag";
 }
 
 const navItems: NavItem[] = [
   { label: "Inbox", nodeId: System.INBOX, icon: "inbox" },
   { label: "The Box", nodeId: System.THE_BOX, icon: "box" },
   { label: "Calendar", nodeId: System.CALENDAR, icon: "calendar" },
+  { label: "Types", nodeId: System.TYPES, icon: "tag" },
 ];
 
 export default function SidebarNav() {
@@ -74,6 +75,18 @@ export default function SidebarNav() {
                   <line x1="16" y1="2" x2="16" y2="6" />
                   <line x1="8" y1="2" x2="8" y2="6" />
                   <line x1="3" y1="10" x2="21" y2="10" />
+                </svg>
+              )}
+              {item.icon === "tag" && (
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  class="w-5 h-5"
+                >
+                  <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
+                  <line x1="7" y1="7" x2="7.01" y2="7" />
                 </svg>
               )}
             </span>

--- a/apps/web/src/ui/Title.tsx
+++ b/apps/web/src/ui/Title.tsx
@@ -226,15 +226,19 @@ export default function Title({ bufferId, nodeId }: TitleProps) {
     Match.value(action).pipe(
       Match.tag("Enter", ({ info }) => {
         if (pickerState()) {
-          const TypePicker = runtime.runSync(TypePickerT);
           const query = getPickerQuery();
-          const types = runtime.runSync(TypePicker.getAvailableTypes());
-          const filtered = TypePicker.filterTypes(types, query);
-          if (filtered.length > 0) {
-            handleTypePickerSelect(filtered[0]!.id);
-          } else if (query) {
-            handleTypePickerCreate(query);
-          }
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const TypePicker = yield* TypePickerT;
+              const types = yield* TypePicker.getAvailableTypes();
+              const filtered = TypePicker.filterTypes(types, query);
+              if (filtered.length > 0) {
+                handleTypePickerSelect(filtered[0]!.id);
+              } else if (query) {
+                handleTypePickerCreate(query);
+              }
+            }),
+          );
           return;
         }
         runtime.runPromise(

--- a/apps/web/src/ui/TypeBadge.tsx
+++ b/apps/web/src/ui/TypeBadge.tsx
@@ -1,7 +1,8 @@
 import { useBrowserRuntime } from "@/context/useBrowserRuntime";
 import { Id } from "@/schema";
-import { YjsT } from "@/services/external/Yjs";
 import { TypeT } from "@/services/domain/Type";
+import { YjsT } from "@/services/external/Yjs";
+import { Badge } from "@kobalte/core/badge";
 import { Effect } from "effect";
 import { createSignal, onCleanup, onMount } from "solid-js";
 
@@ -43,7 +44,10 @@ export default function TypeBadge({ typeId, nodeId, onRemove }: TypeBadgeProps) 
   };
 
   return (
-    <span class="group inline-flex items-center gap-1 px-2 py-0.5 bg-sidebar-accent/80 text-sidebar-foreground text-xs rounded-full">
+    <Badge
+      textValue={`Type: ${name()}`}
+      class="group inline-flex items-center gap-1 px-2 py-0.5 bg-sidebar-accent/80 text-sidebar-foreground text-xs rounded-full whitespace-nowrap"
+    >
       <span class="opacity-60">#</span>
       <span>{name()}</span>
       <button
@@ -61,6 +65,6 @@ export default function TypeBadge({ typeId, nodeId, onRemove }: TypeBadgeProps) 
           <line x1="6" y1="6" x2="18" y2="18" />
         </svg>
       </button>
-    </span>
+    </Badge>
   );
 }

--- a/apps/web/src/ui/TypeBadge.tsx
+++ b/apps/web/src/ui/TypeBadge.tsx
@@ -2,6 +2,7 @@ import { useBrowserRuntime } from "@/context/useBrowserRuntime";
 import { Id } from "@/schema";
 import { TypeT } from "@/services/domain/Type";
 import { YjsT } from "@/services/external/Yjs";
+import { NavigationT } from "@/services/ui/Navigation";
 import { Badge } from "@kobalte/core/badge";
 import { Effect } from "effect";
 import { createSignal, onCleanup, onMount } from "solid-js";
@@ -12,7 +13,11 @@ interface TypeBadgeProps {
   onRemove?: () => void;
 }
 
-export default function TypeBadge({ typeId, nodeId, onRemove }: TypeBadgeProps) {
+export default function TypeBadge({
+  typeId,
+  nodeId,
+  onRemove,
+}: TypeBadgeProps) {
   const runtime = useBrowserRuntime();
   const [name, setName] = createSignal("");
 
@@ -43,27 +48,42 @@ export default function TypeBadge({ typeId, nodeId, onRemove }: TypeBadgeProps) 
     }
   };
 
+  const handleNavigate = (e: MouseEvent) => {
+    e.stopPropagation();
+    runtime.runPromise(
+      Effect.gen(function* () {
+        const Navigation = yield* NavigationT;
+        yield* Navigation.navigateTo(typeId);
+      }),
+    );
+  };
+
   return (
     <Badge
       textValue={`Type: ${name()}`}
-      class="group inline-flex items-center gap-1 px-2 py-0.5 bg-sidebar-accent/80 text-sidebar-foreground text-xs rounded-full whitespace-nowrap"
+      class="group inline-flex items-baseline text-xs whitespace-nowrap rounded bg-type-badge text-type-badge-foreground hover:bg-transparent cursor-pointer"
     >
-      <span class="opacity-60">#</span>
-      <span>{name()}</span>
       <button
         onClick={handleRemove}
-        class="opacity-0 group-hover:opacity-60 hover:!opacity-100 -mr-1 w-4 h-4 flex items-center justify-center"
+        class="pl-1 pr-0.5 opacity-60 group-hover:opacity-100 hover:text-red-500 cursor-pointer"
       >
+        <span class="group-hover:hidden inline-block w-2 max-w-2 text-center">#</span>
         <svg
-          viewBox="0 0 24 24"
+          viewBox="6 6 12 12"
           fill="none"
           stroke="currentColor"
           stroke-width="2"
-          class="w-3 h-3"
+          class="hidden group-hover:block w-2 h-2"
         >
           <line x1="18" y1="6" x2="6" y2="18" />
           <line x1="6" y1="6" x2="18" y2="18" />
         </svg>
+      </button>
+      <button
+        onClick={handleNavigate}
+        class="pr-1 pl-0.5 rounded bg-type-badge text-type-badge-foreground group-hover:shadow-sm cursor-pointer"
+      >
+        {name()}
       </button>
     </Badge>
   );

--- a/apps/web/src/ui/TypeBadge.tsx
+++ b/apps/web/src/ui/TypeBadge.tsx
@@ -1,0 +1,66 @@
+import { useBrowserRuntime } from "@/context/useBrowserRuntime";
+import { Id } from "@/schema";
+import { YjsT } from "@/services/external/Yjs";
+import { TypeT } from "@/services/domain/Type";
+import { Effect } from "effect";
+import { createSignal, onCleanup, onMount } from "solid-js";
+
+interface TypeBadgeProps {
+  typeId: Id.Node;
+  nodeId: Id.Node;
+  onRemove?: () => void;
+}
+
+export default function TypeBadge({ typeId, nodeId, onRemove }: TypeBadgeProps) {
+  const runtime = useBrowserRuntime();
+  const [name, setName] = createSignal("");
+
+  onMount(() => {
+    const Yjs = runtime.runSync(YjsT);
+    const ytext = Yjs.getText(typeId);
+    setName(ytext.toString());
+
+    const observer = () => setName(ytext.toString());
+    ytext.observe(observer);
+
+    onCleanup(() => {
+      ytext.unobserve(observer);
+    });
+  });
+
+  const handleRemove = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (onRemove) {
+      onRemove();
+    } else {
+      runtime.runPromise(
+        Effect.gen(function* () {
+          const Type = yield* TypeT;
+          yield* Type.removeType(nodeId, typeId);
+        }),
+      );
+    }
+  };
+
+  return (
+    <span class="group inline-flex items-center gap-1 px-2 py-0.5 bg-sidebar-accent/80 text-sidebar-foreground text-xs rounded-full">
+      <span class="opacity-60">#</span>
+      <span>{name()}</span>
+      <button
+        onClick={handleRemove}
+        class="opacity-0 group-hover:opacity-60 hover:!opacity-100 -mr-1 w-4 h-4 flex items-center justify-center"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          class="w-3 h-3"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </span>
+  );
+}

--- a/apps/web/src/ui/TypeList.tsx
+++ b/apps/web/src/ui/TypeList.tsx
@@ -1,0 +1,45 @@
+import { useBrowserRuntime } from "@/context/useBrowserRuntime";
+import { Id } from "@/schema";
+import { TypeT } from "@/services/domain/Type";
+import { isSystemType } from "@/services/ui/TypePicker";
+import { Effect, Fiber, Stream } from "effect";
+import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import TypeBadge from "./TypeBadge";
+
+interface TypeListProps {
+  nodeId: Id.Node;
+}
+
+export default function TypeList({ nodeId }: TypeListProps) {
+  const runtime = useBrowserRuntime();
+  const [types, setTypes] = createSignal<readonly Id.Node[]>([]);
+
+  // Filter out system types
+  const userTypes = () => types().filter((typeId) => !isSystemType(typeId));
+
+  onMount(() => {
+    const fiber = runtime.runFork(
+      Effect.gen(function* () {
+        const Type = yield* TypeT;
+        const stream = yield* Type.subscribeTypes(nodeId);
+        yield* Stream.runForEach(stream, (typeIds) =>
+          Effect.sync(() => setTypes(typeIds)),
+        );
+      }),
+    );
+
+    onCleanup(() => {
+      runtime.runFork(Fiber.interrupt(fiber));
+    });
+  });
+
+  return (
+    <Show when={userTypes().length > 0}>
+      <div class="flex flex-wrap gap-1.5 mt-2">
+        <For each={userTypes()}>
+          {(typeId) => <TypeBadge typeId={typeId} nodeId={nodeId} />}
+        </For>
+      </div>
+    </Show>
+  );
+}

--- a/apps/web/src/ui/TypePicker/TypePicker.tsx
+++ b/apps/web/src/ui/TypePicker/TypePicker.tsx
@@ -157,6 +157,7 @@ export default function TypePicker(props: TypePickerProps) {
           <For each={filteredTypes()}>
             {(type, index) => (
               <button
+                type="button"
                 class={`w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left text-sidebar-foreground ${
                   index() === selectedIndex()
                     ? "bg-sidebar-accent"
@@ -184,6 +185,7 @@ export default function TypePicker(props: TypePickerProps) {
 
           <Show when={!hasExactMatch() && props.query}>
             <button
+              type="button"
               class={`w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left text-sidebar-foreground ${
                 selectedIndex() === filteredTypes().length
                   ? "bg-sidebar-accent"

--- a/apps/web/src/ui/TypePicker/TypePicker.tsx
+++ b/apps/web/src/ui/TypePicker/TypePicker.tsx
@@ -1,0 +1,216 @@
+import { useBrowserRuntime } from "@/context/useBrowserRuntime";
+import { Id } from "@/schema";
+import {
+  AvailableType,
+  TypePickerT,
+} from "@/services/ui/TypePicker";
+import { Effect } from "effect";
+import {
+  createEffect,
+  createSignal,
+  For,
+  onCleanup,
+  onMount,
+  Show,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+
+export interface TypePickerProps {
+  /** Position in viewport coordinates */
+  position: { x: number; y: number };
+  /** Current search query (text after "#") */
+  query: string;
+  /** Node to apply type to */
+  nodeId: Id.Node;
+  /** Called when a type is selected */
+  onSelect: (typeId: Id.Node) => void;
+  /** Called when "Create #xyz" is selected */
+  onCreate: (name: string) => void;
+  /** Called when picker should close */
+  onClose: () => void;
+}
+
+export default function TypePicker(props: TypePickerProps) {
+  const runtime = useBrowserRuntime();
+  let containerRef: HTMLDivElement | undefined;
+
+  const [types, setTypes] = createSignal<readonly AvailableType[]>([]);
+  const [filteredTypes, setFilteredTypes] = createSignal<
+    readonly AvailableType[]
+  >([]);
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+
+  onMount(() => {
+    runtime.runPromise(
+      Effect.gen(function* () {
+        const TypePicker = yield* TypePickerT;
+        const available = yield* TypePicker.getAvailableTypes();
+        setTypes(available);
+      }),
+    );
+  });
+
+  createEffect(() => {
+    const available = types();
+    const query = props.query;
+
+    runtime.runSync(
+      Effect.gen(function* () {
+        const TypePicker = yield* TypePickerT;
+        const filtered = TypePicker.filterTypes(available, query);
+        setFilteredTypes(filtered);
+        // Reset selection to first item when filter changes
+        setSelectedIndex(0);
+      }),
+    );
+  });
+
+  // Check if there's an exact match for "Create" option
+  const hasExactMatch = () => {
+    const query = props.query.toLowerCase();
+    if (!query) return true; // Don't show create when no query
+    return filteredTypes().some((t) => t.name.toLowerCase() === query);
+  };
+
+  // Total items including "Create" option
+  const totalItems = () =>
+    filteredTypes().length + (hasExactMatch() ? 0 : 1);
+
+  // Handle keyboard navigation
+  const handleKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex((i) => Math.min(i + 1, totalItems() - 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+        break;
+      case "Enter":
+        e.preventDefault();
+        e.stopPropagation();
+        selectCurrentItem();
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation();
+        props.onClose();
+        break;
+    }
+  };
+
+  const selectCurrentItem = () => {
+    const index = selectedIndex();
+    const filtered = filteredTypes();
+
+    if (index < filtered.length) {
+      // Selected an existing type
+      const type = filtered[index];
+      if (type) {
+        props.onSelect(type.id);
+      }
+    } else {
+      // Selected "Create" option
+      props.onCreate(props.query);
+    }
+  };
+
+  // Click outside detection
+  const handleClickOutside = (e: MouseEvent) => {
+    if (containerRef && !containerRef.contains(e.target as Node)) {
+      props.onClose();
+    }
+  };
+
+  onMount(() => {
+    // Use capture phase so we can intercept before CodeMirror
+    document.addEventListener("keydown", handleKeyDown, true);
+    document.addEventListener("mousedown", handleClickOutside);
+  });
+
+  onCleanup(() => {
+    document.removeEventListener("keydown", handleKeyDown, true);
+    document.removeEventListener("mousedown", handleClickOutside);
+  });
+
+  return (
+    <Portal>
+      <div
+        ref={containerRef}
+        data-testid="type-picker"
+        class="fixed z-50 min-w-48 max-h-64 overflow-y-auto bg-sidebar/95 backdrop-blur-md border border-sidebar-border rounded-lg shadow-daiichi"
+        style={{
+          left: `${props.position.x}px`,
+          top: `${props.position.y}px`,
+        }}
+      >
+        <div class="py-1">
+          <Show when={filteredTypes().length === 0 && !props.query}>
+            <div class="px-3 py-2 text-sm text-sidebar-foreground/60">
+              No types yet. Type a name to create one.
+            </div>
+          </Show>
+
+          <For each={filteredTypes()}>
+            {(type, index) => (
+              <button
+                class={`w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left text-sidebar-foreground ${
+                  index() === selectedIndex()
+                    ? "bg-sidebar-accent"
+                    : "hover:bg-sidebar-accent"
+                }`}
+                onClick={() => props.onSelect(type.id)}
+                onMouseEnter={() => setSelectedIndex(index())}
+              >
+                <span class="w-4 h-4 flex items-center justify-center opacity-60">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    class="w-4 h-4"
+                  >
+                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
+                    <line x1="7" y1="7" x2="7.01" y2="7" />
+                  </svg>
+                </span>
+                <span class="truncate">{type.name}</span>
+              </button>
+            )}
+          </For>
+
+          <Show when={!hasExactMatch() && props.query}>
+            <button
+              class={`w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left text-sidebar-foreground ${
+                selectedIndex() === filteredTypes().length
+                  ? "bg-sidebar-accent"
+                  : "hover:bg-sidebar-accent"
+              }`}
+              onClick={() => props.onCreate(props.query)}
+              onMouseEnter={() => setSelectedIndex(filteredTypes().length)}
+            >
+              <span class="w-4 h-4 flex items-center justify-center opacity-60">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  class="w-4 h-4"
+                >
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+              </span>
+              <span>
+                Create <span class="font-medium">#{props.query}</span>
+              </span>
+            </button>
+          </Show>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/apps/web/src/ui/TypePicker/index.ts
+++ b/apps/web/src/ui/TypePicker/index.ts
@@ -1,0 +1,2 @@
+export { default as TypePicker } from "./TypePicker";
+export type { TypePickerProps } from "./TypePicker";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.39.8
         version: 6.39.8
+      '@kobalte/core':
+        specifier: ^0.13.11
+        version: 0.13.11(solid-js@1.9.10)
       '@livestore/adapter-web':
         specifier: ^0.3.1
         version: 0.3.1(1d62e435dd85889a07eafd78800591dd)
@@ -257,6 +260,11 @@ packages:
 
   '@codemirror/view@6.39.8':
     resolution: {integrity: sha512-1rASYd9Z/mE3tkbC9wInRlCNyCkSn+nLsiQKZhEDUUJiUfs/5FHDpCUDaQpoTIaNGeDc6/bhaEAyLmeEucEFPw==}
+
+  '@corvu/utils@0.4.2':
+    resolution: {integrity: sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==}
+    peerDependencies:
+      solid-js: ^1.8
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -634,6 +642,15 @@ packages:
       '@exodus/crypto':
         optional: true
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -650,6 +667,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@internationalized/date@3.10.1':
+    resolution: {integrity: sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==}
+
+  '@internationalized/number@3.6.5':
+    resolution: {integrity: sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -665,6 +688,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kobalte/core@0.13.11':
+    resolution: {integrity: sha512-hK7TYpdib/XDb/r/4XDBFaO9O+3ZHz4ZWryV4/3BfES+tSQVgg2IJupDnztKXB0BqbSRy/aWlHKw1SPtNPYCFQ==}
+    peerDependencies:
+      solid-js: ^1.8.15
+
+  '@kobalte/utils@0.9.1':
+    resolution: {integrity: sha512-eeU60A3kprIiBDAfv9gUJX1tXGLuZiKMajUfSQURAF2pk4ZoMYiqIzmrMBvzcxP39xnYttgTyQEVLwiTZnrV4w==}
+    peerDependencies:
+      solid-js: ^1.8.8
 
   '@lezer/common@1.3.0':
     resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
@@ -990,13 +1023,58 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@solid-primitives/event-listener@2.4.3':
+    resolution: {integrity: sha512-h4VqkYFv6Gf+L7SQj+Y6puigL/5DIi7x5q07VZET7AWcS+9/G3WfIE9WheniHWJs51OEkRB43w6lDys5YeFceg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/keyed@1.5.2':
+    resolution: {integrity: sha512-BgoEdqPw48URnI+L5sZIHdF4ua4Las1eWEBBPaoSFs42kkhnHue+rwCBPL2Z9ebOyQ75sUhUfOETdJfmv0D6Kg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/map@0.4.13':
+    resolution: {integrity: sha512-B1zyFbsiTQvqPr+cuPCXO72sRuczG9Swncqk5P74NCGw1VE8qa/Ry9GlfI1e/VdeQYHjan+XkbE3rO2GW/qKew==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/media@2.3.3':
+    resolution: {integrity: sha512-hQ4hLOGvfbugQi5Eu1BFWAIJGIAzztq9x0h02xgBGl2l0Jaa3h7tg6bz5tV1NSuNYVGio4rPoa7zVQQLkkx9dA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/props@3.2.2':
+    resolution: {integrity: sha512-lZOTwFJajBrshSyg14nBMEP0h8MXzPowGO0s3OeiR3z6nXHTfj0FhzDtJMv+VYoRJKQHG2QRnJTgCzK6erARAw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
   '@solid-primitives/refs@1.1.2':
     resolution: {integrity: sha512-K7tf2thy7L+YJjdqXspXOg5xvNEOH8tgEWsp0+1mQk3obHBRD6hEjYZk7p7FlJphSZImS35je3UfmWuD7MhDfg==}
     peerDependencies:
       solid-js: ^1.6.12
 
+  '@solid-primitives/resize-observer@2.1.3':
+    resolution: {integrity: sha512-zBLje5E06TgOg93S7rGPldmhDnouNGhvfZVKOp+oG2XU8snA+GoCSSCz1M+jpNAg5Ek2EakU5UVQqL152WmdXQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/rootless@1.5.2':
+    resolution: {integrity: sha512-9HULb0QAzL2r47CCad0M+NKFtQ+LrGGNHZfteX/ThdGvKIg2o2GYhBooZubTCd/RTu2l2+Nw4s+dEfiDGvdrrQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/static-store@0.1.2':
+    resolution: {integrity: sha512-ReK+5O38lJ7fT+L6mUFvUr6igFwHBESZF+2Ug842s7fvlVeBdIVEdTCErygff6w7uR6+jrr7J8jQo+cYrEq4Iw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
   '@solid-primitives/transition-group@1.1.2':
     resolution: {integrity: sha512-gnHS0OmcdjeoHN9n7Khu8KNrOlRc8a2weETDt2YT6o1zeW/XtUC6Db3Q9pkMU/9cCKdEmN4b0a/41MKAHRhzWA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/trigger@1.2.2':
+    resolution: {integrity: sha512-IWoptVc0SWYgmpBPpCMehS5b07+tpFcvw15tOQ3QbXedSYn6KP8zCjPkHNzMxcOvOicTneleeZDP7lqmz+PQ6g==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -1007,6 +1085,9 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -2661,6 +2742,16 @@ packages:
   solid-js@1.9.10:
     resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
 
+  solid-presence@0.1.8:
+    resolution: {integrity: sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA==}
+    peerDependencies:
+      solid-js: ^1.8
+
+  solid-prevent-scroll@0.1.10:
+    resolution: {integrity: sha512-KplGPX2GHiWJLZ6AXYRql4M127PdYzfwvLJJXMkO+CMb8Np4VxqDAg5S8jLdwlEuBis/ia9DKw2M8dFx5u8Mhw==}
+    peerDependencies:
+      solid-js: ^1.8
+
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
     peerDependencies:
@@ -2823,6 +2914,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
@@ -3258,6 +3352,11 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@corvu/utils@0.4.2(solid-js@1.9.10)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      solid-js: 1.9.10
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -3533,6 +3632,17 @@ snapshots:
 
   '@exodus/bytes@1.8.0': {}
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3543,6 +3653,14 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@internationalized/date@3.10.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
+  '@internationalized/number@3.6.5':
+    dependencies:
+      '@swc/helpers': 0.5.18
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3562,6 +3680,29 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kobalte/core@0.13.11(solid-js@1.9.10)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      '@internationalized/date': 3.10.1
+      '@internationalized/number': 3.6.5
+      '@kobalte/utils': 0.9.1(solid-js@1.9.10)
+      '@solid-primitives/props': 3.2.2(solid-js@1.9.10)
+      '@solid-primitives/resize-observer': 2.1.3(solid-js@1.9.10)
+      solid-js: 1.9.10
+      solid-presence: 0.1.8(solid-js@1.9.10)
+      solid-prevent-scroll: 0.1.10(solid-js@1.9.10)
+
+  '@kobalte/utils@0.9.1(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
+      '@solid-primitives/keyed': 1.5.2(solid-js@1.9.10)
+      '@solid-primitives/map': 0.4.13(solid-js@1.9.10)
+      '@solid-primitives/media': 2.3.3(solid-js@1.9.10)
+      '@solid-primitives/props': 3.2.2(solid-js@1.9.10)
+      '@solid-primitives/refs': 1.1.2(solid-js@1.9.10)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
 
   '@lezer/common@1.3.0': {}
 
@@ -3942,7 +4083,52 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.2':
     optional: true
 
+  '@solid-primitives/event-listener@2.4.3(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/keyed@1.5.2(solid-js@1.9.10)':
+    dependencies:
+      solid-js: 1.9.10
+
+  '@solid-primitives/map@0.4.13(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/trigger': 1.2.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/media@2.3.3(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
+      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.10)
+      '@solid-primitives/static-store': 0.1.2(solid-js@1.9.10)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/props@3.2.2(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
   '@solid-primitives/refs@1.1.2(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/resize-observer@2.1.3(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
+      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.10)
+      '@solid-primitives/static-store': 0.1.2(solid-js@1.9.10)
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/rootless@1.5.2(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/static-store@0.1.2(solid-js@1.9.10)':
     dependencies:
       '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
       solid-js: 1.9.10
@@ -3951,11 +4137,20 @@ snapshots:
     dependencies:
       solid-js: 1.9.10
 
+  '@solid-primitives/trigger@1.2.2(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
   '@solid-primitives/utils@6.3.2(solid-js@1.9.10)':
     dependencies:
       solid-js: 1.9.10
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@swc/helpers@0.5.18':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -5798,6 +5993,16 @@ snapshots:
       seroval: 1.3.2
       seroval-plugins: 1.3.3(seroval@1.3.2)
 
+  solid-presence@0.1.8(solid-js@1.9.10):
+    dependencies:
+      '@corvu/utils': 0.4.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  solid-prevent-scroll@0.1.10(solid-js@1.9.10):
+    dependencies:
+      '@corvu/utils': 0.4.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
   solid-refresh@0.6.3(solid-js@1.9.10):
     dependencies:
       '@babel/generator': 7.28.5
@@ -5942,6 +6147,8 @@ snapshots:
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1: {}
 
   tty-browserify@0.0.1: {}
 


### PR DESCRIPTION
## Summary
- Add type picker triggered by `#` in editor - type `#` to open picker and select block types
- Display inline type badges after block text in unfocused state
- Show type badges during CodeMirror editing (focused state)
- Add type picker support to Title component
- Improve TypeBadge hover UX with click-to-navigate functionality
- Extract type badge colors to CSS variables for consistency
- Add Cmd+Opt+Up/Down keyboard shortcuts for block selection mode with smooth animation

## Test plan
- [ ] Type `#` in a block to trigger type picker
- [ ] Select a type and verify badge appears inline
- [ ] Verify badges show in both focused and unfocused states
- [ ] Click badge to navigate to type
- [ ] Test Cmd+Opt+Up/Down for block selection
- [ ] Verify smooth animations on selection changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Type Picker for selecting/creating types on blocks and titles
  * Inline type badges display applied types in-editor
  * New "Types" workspace in the sidebar navigation

* **UX Improvements**
  * Alt+Arrow (and Alt+Shift) block reordering and swapping while preserving selection

* **Tests**
  * Comprehensive browser tests for block movement and Type Picker integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->